### PR TITLE
Add LeadsStream to tap_hubspot_beta for HubSpot CRM integration

### DIFF
--- a/tap_hubspot_beta/client_base.py
+++ b/tap_hubspot_beta/client_base.py
@@ -218,8 +218,9 @@ class hubspotStream(RESTStream):
         headers.update(self.authenticator.auth_headers or {})
         url = self.url_base + self.properties_url
         response = self.request_decorator(self.request_schema)(url, headers=headers)
+        schema_res = response.json()
 
-        fields = response.json().get("results",[]) if response.json.get("results") else response.json()
+        fields = schema_res.get("results",[]) if isinstance(schema_res, dict) and schema_res.get("results") else schema_res
         for field in fields:
             if not field.get("deleted"):
                 property = th.Property(field.get("name"), self.extract_type(field, self.config.get("type_booleancheckbox_as_boolean")))

--- a/tap_hubspot_beta/client_base.py
+++ b/tap_hubspot_beta/client_base.py
@@ -219,7 +219,7 @@ class hubspotStream(RESTStream):
         url = self.url_base + self.properties_url
         response = self.request_decorator(self.request_schema)(url, headers=headers)
 
-        fields = response.json()
+        fields = response.json().get("results",[]) if response.json.get("results") else response.json()
         for field in fields:
             if not field.get("deleted"):
                 property = th.Property(field.get("name"), self.extract_type(field, self.config.get("type_booleancheckbox_as_boolean")))

--- a/tap_hubspot_beta/streams.py
+++ b/tap_hubspot_beta/streams.py
@@ -2541,18 +2541,3 @@ class LeadsStream(ObjectSearchV3):
     properties_url = "crm/v3/properties/leads"
 
     replication_key_filter = "hs_lastmodifieddate"
-
-    @cached_property
-    def schema(self):
-        properties = copy.deepcopy(self.base_properties)
-        headers = self.http_headers
-        headers.update(self.authenticator.auth_headers or {})
-        url = self.url_base + self.properties_url
-        response = self.request_decorator(self.request_schema)(url, headers=headers)
-
-        fields = response.json().get("results",[])
-        for field in fields:
-            if not field.get("deleted"):
-                property = th.Property(field.get("name"), self.extract_type(field, self.config.get("type_booleancheckbox_as_boolean")))
-                properties.append(property)
-        return th.PropertiesList(*properties).to_dict()

--- a/tap_hubspot_beta/streams.py
+++ b/tap_hubspot_beta/streams.py
@@ -2533,22 +2533,15 @@ class GeolocationSummaryMonthlyStream(FormsSummaryMonthlyStream):
         th.Property("end_date", th.DateType),
     ).to_dict() 
 
-class LeadsStream(hubspotV3Stream):
+class LeadsStream(ObjectSearchV3):
     """Leads Stream"""
+
     name = "leads"
-    path = "crm/v3/objects/leads"
-    primary_keys = ["id"]
-    replication_key = None
+    path = "crm/v3/objects/leads/search"
     properties_url = "crm/v3/properties/leads"
-    
-    base_properties = [
-        th.Property("id", th.StringType),
-        th.Property("createdAt", th.DateTimeType),
-        th.Property("updatedAt", th.DateTimeType),
-        th.Property("archived", th.BooleanType),
-        th.Property("archivedAt", th.DateTimeType),
-    ]
-    
+
+    replication_key_filter = "hs_lastmodifieddate"
+
     @cached_property
     def schema(self):
         properties = copy.deepcopy(self.base_properties)

--- a/tap_hubspot_beta/tap.py
+++ b/tap_hubspot_beta/tap.py
@@ -97,7 +97,8 @@ from tap_hubspot_beta.streams import (
     UtmCampaignSummaryMonthlyStream,
     GeolocationSummaryMonthlyStream,
     DealsHistoryPropertiesStream,
-    ContactsHistoryPropertiesStream
+    ContactsHistoryPropertiesStream,
+    LeadsStream
 )
 
 STREAM_TYPES = [
@@ -192,7 +193,8 @@ STREAM_TYPES = [
     UtmCampaignSummaryMonthlyStream,
     GeolocationSummaryMonthlyStream,
     DealsHistoryPropertiesStream,
-    ContactsHistoryPropertiesStream
+    ContactsHistoryPropertiesStream,
+    LeadsStream
 ]
 
 


### PR DESCRIPTION
- Introduced LeadsStream class to handle leads data from HubSpot CRM.
- Defined properties for leads including id, createdAt, updatedAt, archived, and archivedAt.
- Implemented dynamic schema generation for leads properties based on API response.

This addition enhances the data extraction capabilities of the tap_hubspot_beta module.