### PR TITLE
Feature/hgi 7289 - Correctly parse booleans returned by Hubspot on V3 streams

### DIFF
--- a/tap_hubspot_beta/client_base.py
+++ b/tap_hubspot_beta/client_base.py
@@ -339,6 +339,20 @@ class hubspotStream(RESTStream):
                 )
             ]
         return self._stream_maps
+    
+    def parse_value(self, field, value):
+        if "boolean" == self.schema["properties"].get(field, {}).get("type", [""])[0] and value in ["true", "false", "True", "False"]:
+            value = True if value.lower() == "true" else False if value.lower() == "false" else value
+        return value
+
+    def parse_properties(self, row, should_map_id=True):
+        if self.properties_url:
+            for name, value in row["properties"].items():
+                if not should_map_id and name == "id":
+                    continue
+                row[name] = self.parse_value(name, value)
+            del row["properties"]
+        return row
 
 
 class hubspotStreamSchema(hubspotStream):

--- a/tap_hubspot_beta/client_v3.py
+++ b/tap_hubspot_beta/client_v3.py
@@ -138,13 +138,7 @@ class hubspotV3SearchStream(hubspotStream):
 
     def post_process(self, row: dict, context: Optional[dict]) -> dict:
         """As needed, append or transform raw data to match expected structure."""
-        if self.properties_url:
-            for name, value in row["properties"].items():
-                #Skip id property
-                if name == "id":
-                    continue
-                row[name] = value
-            del row["properties"]
+        row = self.parse_properties(row, should_map_id=False)
         return row
 
     def _sync_records(  # noqa C901  # too complex
@@ -322,10 +316,7 @@ class hubspotV3Stream(hubspotStream):
 
     def post_process(self, row: dict, context: Optional[dict]) -> dict:
         """As needed, append or transform raw data to match expected structure."""
-        if self.properties_url:
-            for name, value in row["properties"].items():
-                row[name] = value
-            del row["properties"]
+        row = self.parse_properties(row)
         return row
 
 
@@ -370,10 +361,7 @@ class hubspotV3SingleSearchStream(hubspotStream):
 
     def post_process(self, row: dict, context: Optional[dict]) -> dict:
         """As needed, append or transform raw data to match expected structure."""
-        if self.properties_url:
-            for name, value in row["properties"].items():
-                row[name] = value
-            del row["properties"]
+        row = self.parse_properties(row)
         return row
 
 class AssociationsV3ParentStream(hubspotV3Stream):


### PR DESCRIPTION
V3 Streams will return "False", "True", etc; Causing us to mark all non-null booleans as true (Because the strings are truthy)