### PR TITLE
HGI-7577: parse date fields for fullsync deals

### DIFF
--- a/tap_hubspot_beta/client_base.py
+++ b/tap_hubspot_beta/client_base.py
@@ -268,11 +268,11 @@ class hubspotStream(RESTStream):
         field_type = field.get("type")
         if field_type == "bool" or field.get("fieldType") == "booleancheckbox":
             return th.BooleanType
-        if field_type in ["string", "enumeration", "phone_number", "date", "json", "object_coordinates"]:
+        if field_type in ["string", "enumeration", "phone_number", "json", "object_coordinates"]:
             return th.StringType
         if field_type == "number":
             return th.StringType
-        if field_type == "datetime":
+        if field_type in ["datetime", "date"]:
             return th.DateTimeType
 
         # TODO: Changed default because tap errors if type is None
@@ -309,9 +309,6 @@ class hubspotStream(RESTStream):
             if not field.get("deleted"):
                 property = th.Property(field_name, self.extract_type(field))
                 properties.append(property)
-            
-            if field.get("type") == "date" and hasattr(self, "date_fields"):
-                self.date_fields.append(field_name)
 
         return th.PropertiesList(*properties).to_dict()
 

--- a/tap_hubspot_beta/client_base.py
+++ b/tap_hubspot_beta/client_base.py
@@ -309,6 +309,10 @@ class hubspotStream(RESTStream):
             if not field.get("deleted"):
                 property = th.Property(field_name, self.extract_type(field))
                 properties.append(property)
+            
+            if field.get("type") == "date" and hasattr(self, "date_fields"):
+                self.date_fields.append(field_name)
+
         return th.PropertiesList(*properties).to_dict()
 
     def finalize_state_progress_markers(self, state: Optional[dict] = None) -> None:

--- a/tap_hubspot_beta/streams.py
+++ b/tap_hubspot_beta/streams.py
@@ -1402,7 +1402,6 @@ class FullsyncDealsStream(hubspotV1SplitUrlStream):
     properties_param = "properties"
     merge_pk = "dealId"
     bulk_child_size = 50 # max allowed in the API
-    date_fields = []
 
     base_properties = [
         th.Property("id", th.StringType),
@@ -1503,13 +1502,6 @@ class FullsyncDealsStream(hubspotV1SplitUrlStream):
         row["_hg_archived"] = row.get("archived")
         row["createdAt"] = row.get("hs_createdate")
         row["updatedAt"] = row.get("hs_lastmodifieddate") or row["createdAt"]
-        # deals v1 endpoint returns date fields as timestamps, while search v3 endpoint returns them as date (YYYY-MM-DD)
-        # parse all date fields as (YYYY-MM-DD) strings to match deals stream
-        for field in row:
-            if field in self.date_fields and row[field]:
-                date_value = row[field]
-                date_value = int(date_value) if isinstance(date_value, str) else date_value
-                row[field] = datetime.fromtimestamp(date_value / 1000).strftime('%Y-%m-%d')
         return row
         
     @cached_property


### PR DESCRIPTION
- `fullsync_deals` stream that uses deals v1 endpoint returns date fields as timestamps, while search v3 endpoint returns them as date (YYYY-MM-DD), fixed by parsing all date fields as (YYYY-MM-DD) formatted strings to match deals stream