### PR TITLE
Add marketing emails V3 stream

### DIFF
--- a/tap_hubspot_beta/streams.py
+++ b/tap_hubspot_beta/streams.py
@@ -1294,7 +1294,57 @@ class AssociationContactsCompaniesStream(AssociationContactsStream):
     name = "associations_contacts_companies"
     path = "crm/v4/associations/contacts/companies/batch/read"
 
+class MarketingEmailsV3Stream(hubspotV3Stream):
+    """Marketing Emails V3 Stream"""
 
+    name = "marketing-emails-v3"
+    path = "marketing/v3/emails"
+    replication_key = "updatedAt"
+
+    schema = th.PropertiesList(
+        th.Property("feedbackSurveyId", th.StringType), 
+        th.Property("subject", th.StringType), 
+        th.Property("publishedByEmail", th.StringType), 
+        th.Property("publishDate", th.StringType), 
+        th.Property("isTransactional", th.BooleanType), 
+        th.Property("language", th.StringType), 
+        th.Property("type", th.StringType), 
+        th.Property("campaignUtm", th.StringType), 
+        th.Property("content", th.CustomType({"type": ["object", "string"]})), 
+        th.Property("businessUnitId", th.StringType), 
+        th.Property("webversion", th.CustomType({"type": ["object", "string"]})), 
+        th.Property("archived", th.BooleanType), 
+        th.Property("publishedByName", th.StringType), 
+        th.Property("createdAt", th.StringType), 
+        th.Property("stats", th.CustomType({"type": ["object", "string"]})), 
+        th.Property("jitterSendTime", th.BooleanType), 
+        th.Property("from", th.CustomType({"type": ["object", "string"]})), 
+        th.Property("id", th.StringType), 
+        th.Property("state", th.StringType), 
+        th.Property("createdById", th.StringType), 
+        th.Property("updatedAt", th.StringType), 
+        th.Property("clonedFrom", th.StringType), 
+        th.Property("rssData", th.CustomType({"type": ["object", "string"]})), 
+        th.Property("publishedAt", th.StringType), 
+        th.Property("publishedById", th.StringType), 
+        th.Property("isPublished", th.BooleanType), 
+        th.Property("testing", th.CustomType({"type": ["object", "string"]})), 
+        th.Property("updatedById", th.StringType), 
+        th.Property("folderId", th.IntegerType), 
+        th.Property("emailCampaignGroupId", th.StringType), 
+        th.Property("subscriptionDetails", th.CustomType({"type": ["object", "string"]})), 
+        th.Property("deletedAt", th.StringType), 
+        th.Property("name", th.StringType), 
+        th.Property("activeDomain", th.StringType), 
+        th.Property("campaign", th.StringType), 
+        th.Property("to", th.CustomType({"type": ["object", "string"]})), 
+        th.Property("subcategory", th.StringType), 
+        th.Property("campaignName", th.StringType), 
+        th.Property("sendOnPublish", th.BooleanType), 
+
+    ).to_dict()
+    
+    
 class MarketingEmailsStream(hubspotV1Stream):
     """Marketing Emails Stream"""
 
@@ -1406,7 +1456,7 @@ class MarketingEmailsStream(hubspotV1Stream):
         Per documentation at 
         https://developers.hubspot.com/docs/reference/api/marketing/emails/marketing-emails/v1#get-all-marketing-emails"""
         params: dict = {}
-        self.page_size = 10
+        self.page_size = 100
         params["limit"] = self.page_size
         if next_page_token:
             params.update(next_page_token)

--- a/tap_hubspot_beta/streams.py
+++ b/tap_hubspot_beta/streams.py
@@ -1300,7 +1300,8 @@ class MarketingEmailsV3Stream(hubspotV3Stream):
     name = "marketing_emails_v3"
     path = "marketing/v3/emails"
     replication_key = "updatedAt"
-
+    primary_keys = ["id"]
+    
     schema = th.PropertiesList(
         th.Property("activeDomain", th.StringType), 
         th.Property("allEmailCampaignIds", th.CustomType({"type": ["object", "array"]})), 
@@ -1311,9 +1312,9 @@ class MarketingEmailsV3Stream(hubspotV3Stream):
         th.Property("campaignUtm", th.StringType), 
         th.Property("clonedFrom", th.StringType), 
         th.Property("content", th.CustomType({"type": ["object", "string"]})), 
-        th.Property("createdAt", th.StringType), 
+        th.Property("createdAt", th.DateTimeType), 
         th.Property("createdById", th.StringType), 
-        th.Property("deletedAt", th.StringType), 
+        th.Property("deletedAt", th.DateTimeType), 
         th.Property("emailCampaignGroupId", th.StringType), 
         th.Property("feedbackSurveyId", th.StringType), 
         th.Property("folderId", th.IntegerType), 
@@ -1324,8 +1325,8 @@ class MarketingEmailsV3Stream(hubspotV3Stream):
         th.Property("jitterSendTime", th.BooleanType), 
         th.Property("language", th.StringType), 
         th.Property("name", th.StringType), 
-        th.Property("publishDate", th.StringType), 
-        th.Property("publishedAt", th.StringType), 
+        th.Property("publishDate", th.DateTimeType), 
+        th.Property("publishedAt", th.DateTimeType), 
         th.Property("publishedByEmail", th.StringType), 
         th.Property("publishedById", th.StringType), 
         th.Property("publishedByName", th.StringType), 
@@ -1339,7 +1340,7 @@ class MarketingEmailsV3Stream(hubspotV3Stream):
         th.Property("testing", th.CustomType({"type": ["object", "string"]})), 
         th.Property("to", th.CustomType({"type": ["object", "string"]})), 
         th.Property("type", th.StringType), 
-        th.Property("updatedAt", th.StringType), 
+        th.Property("updatedAt", th.DateTimeType), 
         th.Property("updatedById", th.StringType), 
         th.Property("webversion", th.CustomType({"type": ["object", "string"]})), 
         th.Property("workflowNames", th.CustomType({"type": ["object", "array"]})),  

--- a/tap_hubspot_beta/streams.py
+++ b/tap_hubspot_beta/streams.py
@@ -1296,7 +1296,7 @@ class AssociationContactsCompaniesStream(AssociationContactsStream):
 
 
 class MarketingEmailsStream(hubspotV1Stream):
-    """Dispositions Stream"""
+    """Marketing Emails Stream"""
 
     name = "marketing_emails"
     path = "marketing-emails/v1/emails"

--- a/tap_hubspot_beta/streams.py
+++ b/tap_hubspot_beta/streams.py
@@ -1302,45 +1302,47 @@ class MarketingEmailsV3Stream(hubspotV3Stream):
     replication_key = "updatedAt"
 
     schema = th.PropertiesList(
-        th.Property("feedbackSurveyId", th.StringType), 
-        th.Property("subject", th.StringType), 
-        th.Property("publishedByEmail", th.StringType), 
-        th.Property("publishDate", th.StringType), 
-        th.Property("isTransactional", th.BooleanType), 
-        th.Property("language", th.StringType), 
-        th.Property("type", th.StringType), 
-        th.Property("campaignUtm", th.StringType), 
-        th.Property("content", th.CustomType({"type": ["object", "string"]})), 
-        th.Property("businessUnitId", th.StringType), 
-        th.Property("webversion", th.CustomType({"type": ["object", "string"]})), 
+        th.Property("activeDomain", th.StringType), 
+        th.Property("allEmailCampaignIds", th.CustomType({"type": ["object", "array"]})), 
         th.Property("archived", th.BooleanType), 
-        th.Property("publishedByName", th.StringType), 
+        th.Property("businessUnitId", th.StringType), 
+        th.Property("campaign", th.StringType), 
+        th.Property("campaignName", th.StringType), 
+        th.Property("campaignUtm", th.StringType), 
+        th.Property("clonedFrom", th.StringType), 
+        th.Property("content", th.CustomType({"type": ["object", "string"]})), 
         th.Property("createdAt", th.StringType), 
-        th.Property("stats", th.CustomType({"type": ["object", "string"]})), 
-        th.Property("jitterSendTime", th.BooleanType), 
+        th.Property("createdById", th.StringType), 
+        th.Property("deletedAt", th.StringType), 
+        th.Property("emailCampaignGroupId", th.StringType), 
+        th.Property("feedbackSurveyId", th.StringType), 
+        th.Property("folderId", th.IntegerType), 
         th.Property("from", th.CustomType({"type": ["object", "string"]})), 
         th.Property("id", th.StringType), 
-        th.Property("state", th.StringType), 
-        th.Property("createdById", th.StringType), 
-        th.Property("updatedAt", th.StringType), 
-        th.Property("clonedFrom", th.StringType), 
-        th.Property("rssData", th.CustomType({"type": ["object", "string"]})), 
-        th.Property("publishedAt", th.StringType), 
-        th.Property("publishedById", th.StringType), 
         th.Property("isPublished", th.BooleanType), 
-        th.Property("testing", th.CustomType({"type": ["object", "string"]})), 
-        th.Property("updatedById", th.StringType), 
-        th.Property("folderId", th.IntegerType), 
-        th.Property("emailCampaignGroupId", th.StringType), 
-        th.Property("subscriptionDetails", th.CustomType({"type": ["object", "string"]})), 
-        th.Property("deletedAt", th.StringType), 
+        th.Property("isTransactional", th.BooleanType), 
+        th.Property("jitterSendTime", th.BooleanType), 
+        th.Property("language", th.StringType), 
         th.Property("name", th.StringType), 
-        th.Property("activeDomain", th.StringType), 
-        th.Property("campaign", th.StringType), 
-        th.Property("to", th.CustomType({"type": ["object", "string"]})), 
-        th.Property("subcategory", th.StringType), 
-        th.Property("campaignName", th.StringType), 
+        th.Property("publishDate", th.StringType), 
+        th.Property("publishedAt", th.StringType), 
+        th.Property("publishedByEmail", th.StringType), 
+        th.Property("publishedById", th.StringType), 
+        th.Property("publishedByName", th.StringType), 
+        th.Property("rssData", th.CustomType({"type": ["object", "string"]})), 
         th.Property("sendOnPublish", th.BooleanType), 
+        th.Property("state", th.StringType), 
+        th.Property("stats", th.CustomType({"type": ["object", "string"]})), 
+        th.Property("subcategory", th.StringType), 
+        th.Property("subject", th.StringType), 
+        th.Property("subscriptionDetails", th.CustomType({"type": ["object", "string"]})), 
+        th.Property("testing", th.CustomType({"type": ["object", "string"]})), 
+        th.Property("to", th.CustomType({"type": ["object", "string"]})), 
+        th.Property("type", th.StringType), 
+        th.Property("updatedAt", th.StringType), 
+        th.Property("updatedById", th.StringType), 
+        th.Property("webversion", th.CustomType({"type": ["object", "string"]})), 
+        th.Property("workflowNames", th.CustomType({"type": ["object", "array"]})),  
 
     ).to_dict()
     
@@ -1447,8 +1449,6 @@ class MarketingEmailsStream(hubspotV1Stream):
         th.Property("vidsIncluded", th.CustomType({"type": ["array", "string"]})),
     ).to_dict()
     
-    
-    
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
@@ -1456,33 +1456,12 @@ class MarketingEmailsStream(hubspotV1Stream):
         Per documentation at 
         https://developers.hubspot.com/docs/reference/api/marketing/emails/marketing-emails/v1#get-all-marketing-emails"""
         params: dict = {}
-        self.page_size = 100
         params["limit"] = self.page_size
         if next_page_token:
             params.update(next_page_token)
         params.update(self.additional_prarams)
         params[self.properties_param] = self.selected_properties
         return params
-    
-    def get_next_page_token(
-        self, response: requests.Response, previous_token: Optional[Any]
-    ) -> Optional[Any]:
-        """Override default get_next_page_token method to accurately count objects and return the right offset"""
-        response_json = response.json()
-        self.records_jsonpath = "$.objects[*]"
-        if isinstance(response_json, list):
-            return None
-        if "has-more" not in response_json and "hasMore" not in response_json:
-            items = len(
-                list(extract_jsonpath(self.records_jsonpath, input=response.json()))
-            )
-            if items == self.page_size:
-                previous_token = (
-                    0 if not previous_token else previous_token.get("offset")
-                )
-                offset = self.page_size + previous_token
-                return dict(offset=offset)
-        return None
 
 class PostalMailStream(ObjectSearchV3):
     """Owners Stream"""

--- a/tap_hubspot_beta/streams.py
+++ b/tap_hubspot_beta/streams.py
@@ -1297,7 +1297,7 @@ class AssociationContactsCompaniesStream(AssociationContactsStream):
 class MarketingEmailsV3Stream(hubspotV3Stream):
     """Marketing Emails V3 Stream"""
 
-    name = "marketing-emails-v3"
+    name = "marketing_emails_v3"
     path = "marketing/v3/emails"
     replication_key = "updatedAt"
 

--- a/tap_hubspot_beta/tap.py
+++ b/tap_hubspot_beta/tap.py
@@ -77,6 +77,7 @@ from tap_hubspot_beta.streams import (
     CampaignsStream,
     UsersStream,
     MarketingEmailsV3Stream,
+    ArchivedMarketingEmailsV3Stream,
 )
 
  #When a new stream is added to the tap, it would break existing test suites.
@@ -162,7 +163,8 @@ STREAM_TYPES = add_streams([
     AssociationTasksDealsStream,
     CampaignsStream,
     UsersStream,
-    MarketingEmailsV3Stream
+    MarketingEmailsV3Stream,
+    ArchivedMarketingEmailsV3Stream
 ])
 
 class Taphubspot(Tap):

--- a/tap_hubspot_beta/tap.py
+++ b/tap_hubspot_beta/tap.py
@@ -76,6 +76,7 @@ from tap_hubspot_beta.streams import (
     DiscoverCustomObjectsStream,
     CampaignsStream,
     UsersStream,
+    MarketingEmailsV3Stream,
 )
 
  #When a new stream is added to the tap, it would break existing test suites.
@@ -160,7 +161,8 @@ STREAM_TYPES = add_streams([
     AssociationTasksContactsStream,
     AssociationTasksDealsStream,
     CampaignsStream,
-    UsersStream
+    UsersStream,
+    MarketingEmailsV3Stream
 ])
 
 class Taphubspot(Tap):


### PR DESCRIPTION
This PR makes three changes, all in regards to the Marketing Emails streams.

1. In the current code, the v1 Marketing Emails Stream does not use the correct offset, so the only data that is downloaded is the first 100 returned from the API.  The offset is updated to calculate correctly, using the `limit` query parameter instead of the default `count` query parameter.
2. Adds a new stream for the V3 version of the Marketing Emails endpoint
3. Adds a new stream for Archived Marketing Emails for the V3 endpoint.  The V1 endpoint returns both archived and non-archived records; the V3 endpoint, by default, only returns non-archived records.  Following the example of other Archived Streams in the tap, I added an Archived Marketing Emails V3 stream.

I've executed the changes against our hubspot account, both locally/directly and using Meltano.  

I can provide logs or other proof of the testing, if needed.  I'm also happy to run the code through black/isort/etc. if needed!

Thanks for the creation/development of the tap to this point, and thanks for considering this PR.