### PR TITLE
Update paging for form submissions

### DIFF
--- a/tap_hubspot_beta/streams.py
+++ b/tap_hubspot_beta/streams.py
@@ -566,15 +566,19 @@ class FormSubmissionsStream(hubspotV1Stream):
     name = "form_submissions"
     records_jsonpath = "$.results[*]"
     parent_stream_type = FormsStream
-    # NOTE: There is no primary_key for this stream
+    primary_keys = ["form_id", "conversionId"]
     replication_key = "submittedAt"
     path = "/form-integrations/v1/submissions/forms/{form_id}"
     properties_url = "properties/v2/form_submissions/properties"
+    page_size = 50
+    next_page_token_jsonpath = "$.paging.next.after"
 
     schema = th.PropertiesList(
         th.Property("form_id", th.StringType),
         th.Property("values", th.CustomType({"type": ["array", "string"]})),
         th.Property("submittedAt", th.DateTimeType),
+        th.Property("conversionId", th.StringType),
+        th.Property("pageUrl", th.StringType)
     ).to_dict()
 
     def post_process(self, row: dict, context: Optional[dict]) -> dict:
@@ -582,6 +586,24 @@ class FormSubmissionsStream(hubspotV1Stream):
         row = super().post_process(row, context)
         row["form_id"] = context.get("form_id")
         return row
+    
+    def get_next_page_token(self,
+        response: requests.Response,
+        previous_token: Optional[Any]
+    ) -> Optional[Any]:
+        """
+        Return a token for identifying next page or None, if no more pages.
+        Follows the pattern in the hubspotV1Stream class to return a dictionary with the 
+        key set to the URL parameter used for paging and the value set to the token for the next page
+        """
+        all_matches = extract_jsonpath(
+            self.next_page_token_jsonpath,
+            response.json()
+        )        
+        after_id = next(iter(all_matches), None)
+        if after_id:
+            return dict(after=after_id)
+        return None
 
 
 class OwnersStream(hubspotV3Stream):

--- a/tap_hubspot_beta/streams.py
+++ b/tap_hubspot_beta/streams.py
@@ -604,7 +604,18 @@ class FormSubmissionsStream(hubspotV1Stream):
         if after_id:
             return dict(after=after_id)
         return None
-
+    
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        """Return a dictionary of values to be used in URL parameterization."""
+        params: dict = {}
+        params["limit"] = self.page_size
+        if next_page_token:
+            params.update(next_page_token)
+        params.update(self.additional_prarams)
+        params[self.properties_param] = self.selected_properties
+        return params
 
 class OwnersStream(hubspotV3Stream):
     """Owners Stream"""


### PR DESCRIPTION
The Form Submissions endpoint is a v1 endpoint, but uses a paging method different from the other v1 endpoints.  The v1 endpoints usually have a `has-more` or `hasMore` key, along with an `offset` number.  [Form Submissions](https://developers.hubspot.com/docs/api-reference/legacy/marketing/forms/v1/get-form-integrations-v1-submissions-forms-form_guid) uses a `paging.next.after` setup (similar to the v3 endpoints).

This PR fixes the paging for Form Submissions by defining a `get_next_page_token()` method specific for that endpoint.  Additionally, it sets the max page size correctly for this endpoint (50 instead of the default 100) and sets the correct url parameter for page size (`limit` instead of `count`), defines a primary key based on the form_id and conversionId (according to the documentation, conversionId is `The unique identifier for the form submission`), and adds conversionId and pageUrl as properties for the stream.

Here are sample record counts from our environment with the original versus the counts after this code change as proof/evidence:

Original CNT | New CNT | FORM_ID
-- | -- | --
20 | 3150 | 344661c9
20 | 427 | 21bbcfbb
20 | 363 | c8be661d
20 | 158 | e843f2cd
20 | 136 | 5c757b54
20 | 102 | a1c660d3
20 | 100 | 6b3c35b5
20 | 86 | ae7755b0
20 | 84 | e815f8ac
20 | 77 | 08d2e9f4

Happy to provide any additional testing/evidence you need or want as well!

