### PR TITLE
HG-6073: Add TranscriptsStream to retrieve call transcripts

### DIFF
--- a/tap_hubspot_beta/streams.py
+++ b/tap_hubspot_beta/streams.py
@@ -3248,9 +3248,8 @@ class TranscriptsStream(hubspotV3Stream):
     records_jsonpath = "$"
     parent_stream_type = CallsStream
     bulk_child = False
-    ignore_parent_replication_keys = True
     primary_keys = ["id"]
-    replication_key = "updatedAt"
+    replication_key = None
 
     schema = th.PropertiesList(
         th.Property("id", th.StringType),

--- a/tap_hubspot_beta/streams.py
+++ b/tap_hubspot_beta/streams.py
@@ -1456,7 +1456,10 @@ class CallsStream(ObjectSearchV3):
     properties_url = "properties/v2/calls/properties"
 
     def get_child_context(self, record: dict, context) -> dict:
-        return {"id": record["id"]}
+        return {
+            "id": record["id"],
+            "transcript_id": record.get("hs_call_transcription_id"),
+        }
 
 
 class TasksStream(ObjectSearchV3):
@@ -3221,3 +3224,66 @@ class InboxesStream(hubspotV3Stream):
     ).to_dict()
 
     primary_keys = ["id"]
+
+class TranscriptsStream(hubspotV3Stream):
+    """Call Transcripts Stream.
+
+    Retrieves a call transcript for each parent call that has an
+    ``hs_call_transcription_id`` property set. See:
+    https://developers.hubspot.com/docs/api-reference/latest/crm/extensions/transcriptions/get-transcript
+    """
+
+    name = "transcripts"
+    path = "crm/extensions/calling/2026-03/transcripts/{transcript_id}"
+    records_jsonpath = "$"
+    parent_stream_type = CallsStream
+    bulk_child = False
+    ignore_parent_replication_keys = True
+    primary_keys = ["id"]
+    replication_key = "updatedAt"
+
+    schema = th.PropertiesList(
+        th.Property("id", th.StringType),
+        th.Property("engagementId", th.IntegerType),
+        th.Property("transcriptSource", th.StringType),
+        th.Property("createdAt", th.DateTimeType),
+        th.Property("updatedAt", th.DateTimeType),
+        th.Property(
+            "transcriptUtterances",
+            th.ArrayType(
+                th.ObjectType(
+                    th.Property("id", th.StringType),
+                    th.Property("text", th.StringType),
+                    th.Property("languageCode", th.StringType),
+                    th.Property("startTimeMillis", th.IntegerType),
+                    th.Property("endTimeMillis", th.IntegerType),
+                    th.Property(
+                        "speaker",
+                        th.ObjectType(
+                            th.Property("id", th.StringType),
+                            th.Property("name", th.StringType),
+                            th.Property("email", th.StringType),
+                        ),
+                    ),
+                )
+            ),
+        ),
+    ).to_dict()
+
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        # This endpoint does not accept paging / property selection parameters.
+        return {}
+
+    def get_next_page_token(
+        self, response: requests.Response, previous_token: Optional[Any]
+    ) -> Optional[Any]:
+        return None
+
+    def _sync_records(self, context: Optional[dict] = None) -> None:
+        # Skip requesting the transcript when the parent call does not have an
+        # associated transcription id.
+        if not context or not context.get("transcript_id"):
+            return
+        super()._sync_records(context)

--- a/tap_hubspot_beta/streams.py
+++ b/tap_hubspot_beta/streams.py
@@ -1455,6 +1455,16 @@ class CallsStream(ObjectSearchV3):
     replication_key_filter = "hs_lastmodifieddate"
     properties_url = "properties/v2/calls/properties"
 
+    @cached_property
+    def selected_properties(self):
+        selected_properties = super().selected_properties
+        # Ensure hs_call_transcription_id is fetched so the transcripts child
+        # stream can be populated. This property is required to build the
+        # transcripts API request URL.
+        if "hs_call_transcription_id" not in selected_properties:
+            selected_properties.append("hs_call_transcription_id")
+        return selected_properties
+
     def get_child_context(self, record: dict, context) -> dict:
         return {
             "id": record["id"],

--- a/tap_hubspot_beta/tap.py
+++ b/tap_hubspot_beta/tap.py
@@ -118,6 +118,7 @@ from tap_hubspot_beta.streams import (
     ThreadsStream,
     InboxesStream,
     ChannelsStream,
+    TranscriptsStream,
 )
 
  #When a new stream is added to the tap, it would break existing test suites.
@@ -251,6 +252,7 @@ STREAM_TYPES = add_streams([
     ThreadsStream,
     InboxesStream,
     ChannelsStream,
+    TranscriptsStream,
 ])
 
 


### PR DESCRIPTION
- Introduced TranscriptsStream for fetching call transcripts associated with calls that have a transcription ID.
- Updated CallsStream to return the transcript_id in the context for better integration with the new stream.