### PR TITLE
HGI-10432 | Skip ADHOC lists in list membership sync

### DIFF
--- a/tap_hubspot_beta/streams.py
+++ b/tap_hubspot_beta/streams.py
@@ -1646,6 +1646,7 @@ class ListMembershipV3Stream(hubspotV3Stream):
     records_jsonpath = "$[*]"
     parent_stream_type = ListSearchV3Stream
     primary_keys = ["list_id"]
+    BENIGN_ERROR_CODES = ["INVALID_OBJECT_TYPE_FOR_LIST", "INVALID_PROCESSING_TYPE"]
 
     schema = th.PropertiesList(
         th.Property("results", th.CustomType({"type": ["array", "string"]})),
@@ -1653,12 +1654,12 @@ class ListMembershipV3Stream(hubspotV3Stream):
     ).to_dict()
 
     def validate_response(self, response: requests.Response):
-        if response.status_code == 400 and "INVALID_OBJECT_TYPE_FOR_LIST" in response.text:
+        if response.status_code == 400 and any(code in response.text for code in self.BENIGN_ERROR_CODES):
             return
         super().validate_response(response)
     
     def parse_response(self, response: requests.Response):
-        if response.status_code == 400 and "INVALID_OBJECT_TYPE_FOR_LIST" in response.text:
+        if response.status_code == 400 and any(code in response.text for code in self.BENIGN_ERROR_CODES):
             yield from []
         else:
             yield from super().parse_response(response)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes issue where tap-hubspot-beta fails when attempting to sync list memberships for ADHOC lists, which are not supported by HubSpot's memberships API.

## Changes
- Added `BENIGN_ERROR_CODES` class variable to `ListMembershipV3Stream`
- Included `INVALID_PROCESSING_TYPE` error code for ADHOC lists
- Refactored error checking in `validate_response` and `parse_response` to use `any()` to avoid duplication

## Behavior
When the tap encounters an ADHOC list, it now gracefully skips fetching memberships for that list instead of failing with a 400 error. MANUAL, SNAPSHOT, and DYNAMIC lists continue to sync normally.

## Related
- Fixes HGI-10432
- Job: https://hotglue.com/env/prod.hotglue.mailmodo.com/jobs/Zt_kiDqCs/logs/56ebb343-9ac3-4690-9bad-283791d75645/flows/Zt_kiDqCs/jobs/2026/05/5/31/09/q2hz8H
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HGI-10432](https://linear.app/hotglue/issue/HGI-10432/mailmodo-tap-hubspot-beta-skip-adhoc-lists)

<div><a href="https://cursor.com/agents/bc-d5a7c9d7-3f11-4791-8121-20f21881a920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5a7c9d7-3f11-4791-8121-20f21881a920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

